### PR TITLE
Toon shader constants consolidation

### DIFF
--- a/com.unity.toonshader/Editor/Scripts/GUI/UnityToon3Das2DGUI.cs
+++ b/com.unity.toonshader/Editor/Scripts/GUI/UnityToon3Das2DGUI.cs
@@ -55,7 +55,7 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
         m_normalMapFoldout = true;
         m_outlineFoldout = Toon3Das2DMaterialUtility.IsOutlineEnabled(mat);
 
-        bool lightEnabled = mat.GetInteger(uiElements[SHADER_PROP_DIRECTIONAL_LIGHT_USE].mainProperty.id) != 0;
+        bool lightEnabled = mat.GetInteger(uiElements[ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_USE].mainProperty.id) != 0;
         m_lightingFoldout = lightEnabled;
 
     }
@@ -68,31 +68,31 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
         if (!foldout)
             return;
 
-        ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[SHADER_PROP_MAIN_TEX]);
+        ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_MAIN_TEX]);
 
         EditorGUI.indentLevel += 2;
-        ToonEditorGUIUtility.DrawToggleGUI(mEditor, mats, uiElements[SHADER_PROP_USE_BASE_AS1_ST], out bool applyTo1st);
+        ToonEditorGUIUtility.DrawToggleGUI(mEditor, mats, uiElements[ToonConstants.SHADER_PROP_USE_BASE_AS_1ST], out bool applyTo1st);
         EditorGUI.indentLevel -= 2;
 
         if (applyTo1st) {
             EditorGUI.indentLevel += 2;
-            ToonEditorGUIUtility.DrawColorPropertyGUI(mEditor, uiElements[SHADER_PROP_1_ST_SHADE_COLOR]);
+            ToonEditorGUIUtility.DrawColorPropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_1_ST_SHADE_COLOR]);
             EditorGUI.indentLevel -= 2;
         } else {
-            ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[SHADER_PROP_1_ST_SHADE_MAP]);
+            ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_1_ST_SHADE_MAP]);
         }
 
         EditorGUI.indentLevel += 2;
-        ToonEditorGUIUtility.DrawToggleGUI(mEditor, mats, uiElements[SHADER_PROP_USE_1ST_AS_2ND], out bool applyTo2nd);
+        ToonEditorGUIUtility.DrawToggleGUI(mEditor, mats, uiElements[ToonConstants.SHADER_PROP_USE_1ST_AS_2ND], out bool applyTo2nd);
         EditorGUI.indentLevel -= 2;
 
 
         if (applyTo2nd) {
             EditorGUI.indentLevel += 2;
-            ToonEditorGUIUtility.DrawColorPropertyGUI(mEditor, uiElements[SHADER_PROP_2ND_SHADE_COLOR]);
+            ToonEditorGUIUtility.DrawColorPropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_2ND_SHADE_COLOR]);
             EditorGUI.indentLevel -= 2;
         } else {
-            ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[SHADER_PROP_2ND_SHADE_MAP]);
+            ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_2ND_SHADE_MAP]);
         }
 
         EditorGUILayout.Space();
@@ -108,14 +108,14 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
 
         EditorGUILayout.LabelField("Base to 1st Shade");
         EditorGUI.indentLevel += INDENT_SIZE;
-        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[SHADER_PROP_BASE_TO_1ST_SHADE_START]);
-        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[SHADER_PROP_BASE_TO_1ST_SHADE_FEATHER]);
+        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_BASE_TO_1ST_SHADE_START]);
+        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_BASE_TO_1ST_SHADE_FEATHER]);
         EditorGUI.indentLevel -= INDENT_SIZE;
 
         EditorGUILayout.LabelField("1st to 2nd Shade");
         EditorGUI.indentLevel += INDENT_SIZE;
-        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[SHADER_PROP_1ST_TO_2ND_SHADE_START]);
-        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[SHADER_PROP_1ST_TO_2ND_SHADE_FEATHER]);
+        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_1ST_TO_2ND_SHADE_START]);
+        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_1ST_TO_2ND_SHADE_FEATHER]);
         EditorGUI.indentLevel -= INDENT_SIZE;
 
         EditorGUILayout.Space();
@@ -133,10 +133,10 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
         if (!foldout)
             return;
 
-        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[SHADER_PROP_2D_LIGHT_STRENGTH]);
+        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_2D_LIGHT_STRENGTH]);
         EditorGUILayout.Space();
 
-        ToonEditorGUIUtility.DrawToggleGUI(mEditor, mats, uiElements[SHADER_PROP_DIRECTIONAL_LIGHT_USE],
+        ToonEditorGUIUtility.DrawToggleGUI(mEditor, mats, uiElements[ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_USE],
             out bool directionalLightEnabled);
 
         EditorGUI.indentLevel += INDENT_SIZE;
@@ -145,16 +145,16 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
         ToonEditorGUIUtility.DrawVector3FieldGUI(mEditor, mats, uiElements[ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_DIRECTION]);
         ToonEditorGUIUtility.DrawColorFieldGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_COLOR]);
         ToonEditorGUIUtility.DrawFloatFieldGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_INTENSITY]);
-        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[SHADER_PROP_DIRECTIONAL_LIGHT_DIFFUSE_STRENGTH]);
+        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_DIFFUSE_STRENGTH]);
 
         EditorGUILayout.LabelField("Highlight Settings");
         EditorGUI.indentLevel += INDENT_SIZE;
         ToonEditorGUIUtility.DrawVector3FieldGUI(mEditor, mats, uiElements[ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_VIEW_POSITION]);
-        ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[SHADER_PROP_HIGHLIGHT_TEX]);
-        ToonEditorGUIUtility.DrawIntPopupGUI(mEditor, mats, uiElements[SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_MODE],
+        ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_HIGHLIGHT_TEX]);
+        ToonEditorGUIUtility.DrawIntPopupGUI(mEditor, mats, uiElements[ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_MODE],
             m_highlightModeEnums, m_highlightModeIndices, out int _);
-        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_STRENGTH]);
-        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_SIZE]);
+        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_STRENGTH]);
+        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_SIZE]);
 
         EditorGUI.indentLevel -= INDENT_SIZE;
 
@@ -169,12 +169,12 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
     static void DrawNormalMapGUI(MaterialEditor mEditor, Dictionary<string, MaterialPropertyUIElement> uiElements,
         ref bool foldout) {
 
-        ToonEditorGUIUtility.DrawFoldoutGUI(ref foldout, uiElements[SHADER_PROP_NORMAL_MAP].label);
+        ToonEditorGUIUtility.DrawFoldoutGUI(ref foldout, uiElements[ToonConstants.SHADER_PROP_NORMAL_MAP].label);
         if (!foldout)
             return;
 
-        ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[SHADER_PROP_NORMAL_MAP]);
-        mEditor.TextureScaleOffsetProperty(uiElements[SHADER_PROP_NORMAL_MAP].mainProperty.prop);
+        ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_NORMAL_MAP]);
+        mEditor.TextureScaleOffsetProperty(uiElements[ToonConstants.SHADER_PROP_NORMAL_MAP].mainProperty.prop);
 
         EditorGUILayout.Space();
     }
@@ -199,32 +199,32 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
 
         EditorGUI.BeginDisabledGroup(outlineMode != (int)ToonOutlineMode.NormalDirection);
         {
-            ToonEditorGUIUtility.DrawToggleGUI(mEditor, mats, uiElements[SHADER_PROP_OUTLINE_USE_NORMAL_MAP],
+            ToonEditorGUIUtility.DrawToggleGUI(mEditor, mats, uiElements[ToonConstants.SHADER_PROP_OUTLINE_USE_NORMAL_MAP],
                 out bool useCustom);
             EditorGUI.BeginDisabledGroup(!useCustom);
-            ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[SHADER_PROP_OUTLINE_NORMAL_MAP]);
+            ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_OUTLINE_NORMAL_MAP]);
             EditorGUI.EndDisabledGroup();
         }
         EditorGUI.EndDisabledGroup();
 
 
-        ToonEditorGUIUtility.DrawFloatFieldGUI(mEditor, uiElements[SHADER_PROP_OUTLINE_WIDTH]);
-        ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[SHADER_PROP_OUTLINE_WIDTH_MAP]);
+        ToonEditorGUIUtility.DrawFloatFieldGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_OUTLINE_WIDTH]);
+        ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_OUTLINE_WIDTH_MAP]);
 
-        ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[SHADER_PROP_OUTLINE_TEX]);
-        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[SHADER_PROP_OUTLINE_BASE_COLOR_BLEND]);
-        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[SHADER_PROP_OUTLINE_LIGHT_COLOR_BLEND]);
+        ToonEditorGUIUtility.DrawTexturePropertySingleLineGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_OUTLINE_TEX]);
+        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_OUTLINE_BASE_COLOR_BLEND]);
+        ToonEditorGUIUtility.DrawRangePropertyGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_OUTLINE_LIGHT_COLOR_BLEND]);
 
 
-        ToonEditorGUIUtility.DrawFloatFieldGUI(mEditor, uiElements[SHADER_PROP_OUTLINE_OFFSET_Z]);
+        ToonEditorGUIUtility.DrawFloatFieldGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_OUTLINE_OFFSET_Z]);
 
 
         EditorGUILayout.Space();
         {
             EditorGUILayout.LabelField("Camera Distance for Outline Width");
             EditorGUI.indentLevel++;
-            ToonEditorGUIUtility.DrawFloatFieldGUI(mEditor, uiElements[SHADER_PROP_OUTLINE_NEAR]);
-            ToonEditorGUIUtility.DrawFloatFieldGUI(mEditor, uiElements[SHADER_PROP_OUTLINE_FAR]);
+            ToonEditorGUIUtility.DrawFloatFieldGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_OUTLINE_NEAR]);
+            ToonEditorGUIUtility.DrawFloatFieldGUI(mEditor, uiElements[ToonConstants.SHADER_PROP_OUTLINE_FAR]);
             EditorGUI.indentLevel--;
 
 
@@ -278,29 +278,29 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
     static readonly Dictionary<string, string> TOON_3D_AS_2D_TO_3D_MAP = new Dictionary<string, string> {
 
         // Shading thresholds
-        { ToonConstants.SHADER_PROP_BASE_TO_1ST_SHADE_START, "_BaseColor_Step" },
-        { ToonConstants.SHADER_PROP_BASE_TO_1ST_SHADE_FEATHER, "_BaseShade_Feather" },
-        { ToonConstants.SHADER_PROP_1ST_TO_2ND_SHADE_START, "_1st_ShadeColor_Step" },
-        { ToonConstants.SHADER_PROP_1ST_TO_2ND_SHADE_FEATHER, "_1st_ShadeColor_Feather" },
+        { ToonConstants.SHADER_PROP_BASE_TO_1ST_SHADE_START, ToonConstants.SHADER_PROP_TOON3D_BASE_COLOR_STEP },
+        { ToonConstants.SHADER_PROP_BASE_TO_1ST_SHADE_FEATHER, ToonConstants.SHADER_PROP_TOON3D_BASE_SHADE_FEATHER },
+        { ToonConstants.SHADER_PROP_1ST_TO_2ND_SHADE_START, ToonConstants.SHADER_PROP_TOON3D_1ST_SHADE_COLOR_STEP },
+        { ToonConstants.SHADER_PROP_1ST_TO_2ND_SHADE_FEATHER, ToonConstants.SHADER_PROP_TOON3D_1ST_SHADE_COLOR_FEATHER },
 
         // Highlight
-        { ToonConstants.SHADER_PROP_HIGHLIGHT_COLOR, "_HighColor" },
-        { ToonConstants.SHADER_PROP_HIGHLIGHT_TEX, "_HighColor_Tex" },
+        { ToonConstants.SHADER_PROP_HIGHLIGHT_COLOR, ToonConstants.SHADER_PROP_TOON3D_HIGH_COLOR },
+        { ToonConstants.SHADER_PROP_HIGHLIGHT_TEX, ToonConstants.SHADER_PROP_TOON3D_HIGH_COLOR_TEX },
 
         // Outline
-        { ToonConstants.SHADER_PROP_OUTLINE_MODE, "_OUTLINE" },
-        { ToonConstants.SHADER_PROP_OUTLINE_WIDTH, "_Outline_Width" },
-        { ToonConstants.SHADER_PROP_OUTLINE_WIDTH_MAP, "_Outline_Sampler" },
-        { ToonConstants.SHADER_PROP_OUTLINE_COLOR, "_Outline_Color" },
-        { ToonConstants.SHADER_PROP_OUTLINE_BASE_COLOR_BLEND, "_Is_BlendBaseColor" },
-        { ToonConstants.SHADER_PROP_OUTLINE_LIGHT_COLOR_BLEND, "_Is_LightColor_Outline" },
-        { ToonConstants.SHADER_PROP_OUTLINE_OFFSET_Z, "_Offset_Z" },
-        { ToonConstants.SHADER_PROP_OUTLINE_NEAR, "_Nearest_Distance" },
-        { ToonConstants.SHADER_PROP_OUTLINE_FAR, "_Farthest_Distance" },
+        { ToonConstants.SHADER_PROP_OUTLINE_MODE, ToonConstants.SHADER_PROP_TOON3D_OUTLINE },
+        { ToonConstants.SHADER_PROP_OUTLINE_WIDTH, ToonConstants.SHADER_PROP_TOON3D_OUTLINE_WIDTH },
+        { ToonConstants.SHADER_PROP_OUTLINE_WIDTH_MAP, ToonConstants.SHADER_PROP_TOON3D_OUTLINE_SAMPLER },
+        { ToonConstants.SHADER_PROP_OUTLINE_COLOR, ToonConstants.SHADER_PROP_TOON3D_OUTLINE_COLOR },
+        { ToonConstants.SHADER_PROP_OUTLINE_BASE_COLOR_BLEND, ToonConstants.SHADER_PROP_TOON3D_IS_BLEND_BASE_COLOR },
+        { ToonConstants.SHADER_PROP_OUTLINE_LIGHT_COLOR_BLEND, ToonConstants.SHADER_PROP_TOON3D_IS_LIGHT_COLOR_OUTLINE },
+        { ToonConstants.SHADER_PROP_OUTLINE_OFFSET_Z, ToonConstants.SHADER_PROP_TOON3D_OFFSET_Z },
+        { ToonConstants.SHADER_PROP_OUTLINE_NEAR, ToonConstants.SHADER_PROP_TOON3D_NEAREST_DISTANCE },
+        { ToonConstants.SHADER_PROP_OUTLINE_FAR, ToonConstants.SHADER_PROP_TOON3D_FARTHEST_DISTANCE },
 
         // Outline normal options (closest equivalents)
-        { ToonConstants.SHADER_PROP_OUTLINE_USE_NORMAL_MAP, "_Is_BakedNormal" },
-        { ToonConstants.SHADER_PROP_OUTLINE_NORMAL_MAP, "_BakedNormal" },
+        { ToonConstants.SHADER_PROP_OUTLINE_USE_NORMAL_MAP, ToonConstants.SHADER_PROP_TOON3D_IS_BAKED_NORMAL },
+        { ToonConstants.SHADER_PROP_OUTLINE_NORMAL_MAP, ToonConstants.SHADER_PROP_TOON3D_BAKED_NORMAL },
     };
  
 
@@ -361,70 +361,70 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
     
     private static readonly List<MaterialUIElement> m_materialUIElements = new List<MaterialUIElement>() {
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_MAIN_TEX),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_MAIN_TEX),
             label = new GUIContent("Base Map", "Base Color : Texture(sRGB) × Color(RGB)."),
-            extraPropertyName1 = new MaterialName(SHADER_PROP_BASE_COLOR),
+            extraPropertyName1 = new MaterialName(ToonConstants.SHADER_PROP_BASE_COLOR),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_1_ST_SHADE_MAP),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_1_ST_SHADE_MAP),
             label = new GUIContent("1st Shading Map", "The map used for the brighter portions of the shadow."),
-            extraPropertyName1 = new MaterialName(SHADER_PROP_1_ST_SHADE_COLOR),
+            extraPropertyName1 = new MaterialName(ToonConstants.SHADER_PROP_1_ST_SHADE_COLOR),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_1_ST_SHADE_COLOR),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_1_ST_SHADE_COLOR),
             label = new GUIContent("1st Shading Map", "The map used for the brighter portions of the shadow."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_2ND_SHADE_MAP),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_2ND_SHADE_MAP),
             label = new GUIContent("2nd Shading Map", "The map used for the darker portions of the shadow."),
-            extraPropertyName1 = new MaterialName(SHADER_PROP_2ND_SHADE_COLOR)
+            extraPropertyName1 = new MaterialName(ToonConstants.SHADER_PROP_2ND_SHADE_COLOR)
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_2ND_SHADE_COLOR),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_2ND_SHADE_COLOR),
             label = new GUIContent("2nd Shading Map", "The map used for the darker portions of the shadow."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_USE_BASE_AS1_ST),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_USE_BASE_AS_1ST),
             label = new GUIContent("Apply to 1st shading map", "Apply Base map to the 1st shading map."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_USE_1ST_AS_2ND),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_USE_1ST_AS_2ND),
             label = new GUIContent("Apply to 2nd shading map", "Apply Base map or the 1st shading map to the 2st shading map."),
         },
 
         //Shading
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_BASE_TO_1ST_SHADE_START),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_BASE_TO_1ST_SHADE_START),
             label = new GUIContent("Start",
                 "The threshold for transitioning to the 1st shade color. " +
                 "0: use the base color (no transition), " +
                 "1: starts transitioning immediately."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_BASE_TO_1ST_SHADE_FEATHER),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_BASE_TO_1ST_SHADE_FEATHER),
             label = new GUIContent("Feather", "Controls feathering to the 1st shade color. 0: sharp transition, 1: fully feathered."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_1ST_TO_2ND_SHADE_START),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_1ST_TO_2ND_SHADE_START),
             label = new GUIContent("Start",
                 "The threshold for transitioning to the 2nd shade color. " +
                 "0: use the 1st shade color (no transition), " +
                 "1: starts transitioning immediately."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_1ST_TO_2ND_SHADE_FEATHER),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_1ST_TO_2ND_SHADE_FEATHER),
             label = new GUIContent("Feather", "Controls feathering to the 2nd shade color. 0: sharp transition, 1: fully feathered."),
         },
 
         //Lighting
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_2D_LIGHT_STRENGTH),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_2D_LIGHT_STRENGTH),
             label = new GUIContent("2D Light Factor",
                 "Multiplier for the 2D light contribution."),
         },
         //Custom Directional Light
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_DIRECTIONAL_LIGHT_USE),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_USE),
             label = new GUIContent("Custom Directional Light",
                 "Apply a custom directional light."),
         },
@@ -444,7 +444,7 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
                 "The intensity of the custom directional light. "),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_DIRECTIONAL_LIGHT_DIFFUSE_STRENGTH),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_DIFFUSE_STRENGTH),
             label = new GUIContent("Diffuse Strength",
                 "Multiplier for the diffuse contribution."),
         },
@@ -453,69 +453,69 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
             label = new GUIContent("View Position", "Camera View Position"),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_HIGHLIGHT_TEX),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_HIGHLIGHT_TEX),
             label = new GUIContent("Highlight Map", "Highlight Map."),
-            extraPropertyName1 = new MaterialName(SHADER_PROP_HIGHLIGHT_COLOR)
+            extraPropertyName1 = new MaterialName(ToonConstants.SHADER_PROP_HIGHLIGHT_COLOR)
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_MODE),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_MODE),
             label = new GUIContent("Mode", "Highlight mode."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_STRENGTH),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_STRENGTH),
             label = new GUIContent("Highlight Strength", "Multiplier for the highlight contribution."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_SIZE),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_SIZE),
             label = new GUIContent("Highlight Size", "Highlight size."),
         },
 
 
         //Normal Map
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_NORMAL_MAP),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_NORMAL_MAP),
             label = new GUIContent("Normal Map", "A texture that specifies the bumpiness of the material."),
-            extraPropertyName1 = new MaterialName(SHADER_PROP_BUMP_SCALE),
+            extraPropertyName1 = new MaterialName(ToonConstants.SHADER_PROP_BUMP_SCALE),
         },
 
         //Outline Start
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_OUTLINE_WIDTH),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_WIDTH),
             label = new GUIContent("Outline Width",
                 "The width of the outline."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_OUTLINE_WIDTH_MAP),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_WIDTH_MAP),
             label = new GUIContent("Outline Width Map",
                 "Outline Width Map (grayscale, linear): White = full width, Black = 0 width."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_OUTLINE_TEX),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_TEX),
             label = new GUIContent("Outline Color", "The color of outline."),
-            extraPropertyName1 = new MaterialName(SHADER_PROP_OUTLINE_COLOR),
+            extraPropertyName1 = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_COLOR),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_OUTLINE_BASE_COLOR_BLEND),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_BASE_COLOR_BLEND),
             label = new GUIContent("Blend Base Color to Outline",
                 "Blend base color to outline color."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_OUTLINE_LIGHT_COLOR_BLEND),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_LIGHT_COLOR_BLEND),
             label = new GUIContent("Blend Light Color to Outline",
                 "Blend the combined effect of 2D lighting and custom directional light to the outline color."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_OUTLINE_OFFSET_Z),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_OFFSET_Z),
             label = new GUIContent("Z Offset",
                 "Offsets the outline in the depth (Z) direction of the camera."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_OUTLINE_NEAR),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_NEAR),
             label = new GUIContent("Near",
                 "Nearest distance for maximum outline width."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_OUTLINE_FAR),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_FAR),
             label = new GUIContent("Far",
                 "Furthest distance where outline fades to zero width."),
         },
@@ -525,70 +525,19 @@ internal class UnityToon3Das2DGUI : UnityEditor.ShaderGUI {
                 "Specifies how the outline is generated."),
         },
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_OUTLINE_USE_NORMAL_MAP),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_USE_NORMAL_MAP),
             label = new GUIContent("Use Normal Map",
                 "Use a normal map for outline."),
         },
 
         new MaterialUIElement {
-            mainPropertyName = new MaterialName(SHADER_PROP_OUTLINE_NORMAL_MAP),
+            mainPropertyName = new MaterialName(ToonConstants.SHADER_PROP_OUTLINE_NORMAL_MAP),
             label = new GUIContent("Normal Map",
                 "Normal map for outline. "),
         },
         //Outline End
 
     };
-
-
-    //Common constants
-    //Colors
-    internal const string SHADER_PROP_BASE_COLOR = "_BaseColor";
-    internal const string SHADER_PROP_MAIN_TEX = "_MainTex";
-
-    internal const string SHADER_PROP_1_ST_SHADE_COLOR = "_1st_ShadeColor";
-    internal const string SHADER_PROP_1_ST_SHADE_MAP = "_1st_ShadeMap";
-    internal const string SHADER_PROP_USE_BASE_AS1_ST = "_Use_BaseAs1st";
-
-    internal const string SHADER_PROP_2ND_SHADE_COLOR = "_2nd_ShadeColor";
-    internal const string SHADER_PROP_2ND_SHADE_MAP = "_2nd_ShadeMap";
-    internal const string SHADER_PROP_USE_1ST_AS_2ND = "_Use_1stAs2nd";
-
-    //Shading
-    internal const string SHADER_PROP_BASE_TO_1ST_SHADE_START = "_BaseTo1st_ShadeStart";
-    internal const string SHADER_PROP_BASE_TO_1ST_SHADE_FEATHER = "_BaseTo1st_ShadeFeather";
-    internal const string SHADER_PROP_1ST_TO_2ND_SHADE_START = "_1stTo2nd_ShadeStart";
-    internal const string SHADER_PROP_1ST_TO_2ND_SHADE_FEATHER = "_1stTo2nd_ShadeFeather";
-
-    internal const string SHADER_PROP_2D_LIGHT_STRENGTH = "_2DLightStrength";
-
-    //Lighting
-    internal const string SHADER_PROP_DIRECTIONAL_LIGHT_USE = "_DirectionalLight_Use";
-    internal const string SHADER_PROP_DIRECTIONAL_LIGHT_DIFFUSE_STRENGTH = "_DirectionalLight_DiffuseStrength";
-
-
-    internal const string SHADER_PROP_HIGHLIGHT_COLOR = "_HighlightColor";
-    internal const string SHADER_PROP_HIGHLIGHT_TEX = "_HighlightTex";
-    internal const string SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_MODE = "_DirectionalLight_HighlightMode";
-    internal const string SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_STRENGTH = "_DirectionalLight_HighlightStrength";
-    internal const string SHADER_PROP_DIRECTIONAL_LIGHT_HIGHLIGHT_SIZE = "_DirectionalLight_HighlightSize";
-
-
-
-    internal const string SHADER_PROP_NORMAL_MAP = "_NormalMap";
-    internal const string SHADER_PROP_BUMP_SCALE = "_BumpScale";
-
-    internal const string SHADER_PROP_OUTLINE_WIDTH = "_OutlineWidth";
-    internal const string SHADER_PROP_OUTLINE_WIDTH_MAP = "_OutlineWidthMap";
-    internal const string SHADER_PROP_OUTLINE_TEX = "_OutlineTex";
-    internal const string SHADER_PROP_OUTLINE_COLOR = "_OutlineColor";
-    internal const string SHADER_PROP_OUTLINE_BASE_COLOR_BLEND = "_Outline_BaseColorBlend";
-    internal const string SHADER_PROP_OUTLINE_LIGHT_COLOR_BLEND = "_Outline_LightColorBlend";
-    internal const string SHADER_PROP_OUTLINE_OFFSET_Z = "_OutlineOffsetZ";
-    internal const string SHADER_PROP_OUTLINE_NEAR = "_OutlineNear";
-    internal const string SHADER_PROP_OUTLINE_FAR = "_OutlineFar";
-
-    internal const string SHADER_PROP_OUTLINE_USE_NORMAL_MAP = "_Outline_UseNormalMap";
-    internal const string SHADER_PROP_OUTLINE_NORMAL_MAP = "_Outline_NormalMap";
 
 
     internal enum HighlightMode {

--- a/com.unity.toonshader/Editor/ToonGUI-RenderingPerChannel.cs
+++ b/com.unity.toonshader/Editor/ToonGUI-RenderingPerChannel.cs
@@ -3,6 +3,7 @@
 //toshiyuki@unity3d.com (Universal RP/HDRP)
 
 using System.Collections.Generic;
+using Unity.Rendering.Toon;
 using UnityEditorInternal;
 using UnityEngine;
 
@@ -73,11 +74,11 @@ namespace UnityEditor.Rendering.Toon
         void SetuClippingMatte(Material material)
         {
 
-            material.DisableKeyword(ShaderDefineIS_CLIPPING_MATTE);
+            material.DisableKeyword(ToonConstants.SHADER_KEYWORD_IS_CLIPPING_MATTE);
             if (m_selectedIndex != 0 )
             {
 
-                material.EnableKeyword(ShaderDefineIS_CLIPPING_MATTE);
+                material.EnableKeyword(ToonConstants.SHADER_KEYWORD_IS_CLIPPING_MATTE);
             }
             material.SetInt("_ClippingMatteMode", m_selectedIndex);
         }

--- a/com.unity.toonshader/Editor/UTS3GUI.cs
+++ b/com.unity.toonshader/Editor/UTS3GUI.cs
@@ -57,13 +57,12 @@ namespace UnityEditor.Rendering.Toon {
         internal static string srpDefaultLightModeName {
             get {
                 const string legacyDefaultLightModeName = "Always";
-                const string srpDefaultLightModeName = "SRPDefaultUnlit";
 
                 if (currentRenderPipeline == RenderPipeline.Legacy) {
                     return legacyDefaultLightModeName; // default.
                 }
 
-                return srpDefaultLightModeName;
+                return ToonConstants.SHADER_LIGHT_MODE_NAME_FOR_OUTLINE;
             }
         }
 
@@ -187,8 +186,6 @@ namespace UnityEditor.Rendering.Toon {
 
         internal const string ShaderDefineIS_TRANSCLIPPING_OFF = "_IS_TRANSCLIPPING_OFF";
         internal const string ShaderDefineIS_TRANSCLIPPING_ON = "_IS_TRANSCLIPPING_ON";
-
-        internal const string ShaderDefineIS_CLIPPING_MATTE = "_IS_CLIPPING_MATTE";
 
 
         protected readonly string[] UtsModeNames = { "Standard", "With Additional Control Maps" };

--- a/com.unity.toonshader/Editor/UTS3GUI.cs
+++ b/com.unity.toonshader/Editor/UTS3GUI.cs
@@ -98,13 +98,10 @@ namespace UnityEditor.Rendering.Toon {
         internal const string ShaderProp_Set_2nd_ShadePosition = "_Set_2nd_ShadePosition";
         internal const string ShaderProp_ShadingGradeMap = "_ShadingGradeMap";
         internal const string ShaderProp_Set_RimLightMask = "_Set_RimLightMask";
-        internal const string ShaderProp_HighColor_Tex = "_HighColor_Tex";
         internal const string ShaderProp_Set_HighColorMask = "_Set_HighColorMask";
         internal const string ShaderProp_MatCap_Sampler = "_MatCap_Sampler";
         internal const string ShaderProp_Set_MatcapMask = "_Set_MatcapMask";
         
-        internal const string ShaderProp_Outline_Sampler = "_Outline_Sampler";
-
         internal const string ShaderPropSimpleUI = "_simpleUI";
         internal const string ShaderPropUtsTechniqe = "_utsTechnique";
         internal const string ShaderPropAutoRenderQueue = "_AutoRenderQueue";
@@ -117,7 +114,6 @@ namespace UnityEditor.Rendering.Toon {
         internal const string ShaderPropStencilWriteMask = "_StencilWriteMask";
         internal const string ShaderPropStencilReadMask = "_StencilReadMask";
         internal const string ShaderPropIsUnityToonShader = "_isUnityToonshader";
-        internal const string ShaderPropOutline = "_OUTLINE";
         internal const string ShaderPropNormalMapToHighColor = "_Is_NormalMapToHighColor";
         internal const string ShaderPropIsNormalMapToRimLight = "_Is_NormalMapToRimLight";
         internal const string ShaderPropSetSystemShadowsToBase = "_Set_SystemShadowsToBase";
@@ -139,7 +135,6 @@ namespace UnityEditor.Rendering.Toon {
         internal const string ShaderPropIs_LightColor_Ap_RimLight = "_Is_LightColor_Ap_RimLight";
         internal const string ShaderPropIs_LightColor_MatCap = "_Is_LightColor_MatCap";
         internal const string ShaderPropIs_LightColor_AR = "_Is_LightColor_AR";
-        internal const string ShaderPropIs_LightColor_Outline = "_Is_LightColor_Outline";
         internal const string ShaderPropInvert_MatcapMask = "_Inverse_MatcapMask";
         internal const string ShaderPropIs_NormalMapToBase = "_Is_NormalMapToBase";
         internal const string ShaderPropIs_ColorShift = "_Is_ColorShift";
@@ -156,10 +151,6 @@ namespace UnityEditor.Rendering.Toon {
         internal const string ShaderPropAdd_Antipodean_RimLight = "_Add_Antipodean_RimLight";
         internal const string ShaderPropLightDirection_MaskOn = "_LightDirection_MaskOn";
 
-        internal const string ShaderProp1st_ShadeColor_Step = "_1st_ShadeColor_Step";
-        internal const string ShaderPropBaseColor_Step = "_BaseColor_Step";
-        internal const string ShaderProp1st_ShadeColor_Feather = "_1st_ShadeColor_Feather";
-        internal const string ShaderPropBaseShade_Feather = "_BaseShade_Feather";
         internal const string ShaderProp2nd_ShadeColor_Step = "_2nd_ShadeColor_Step";
         internal const string ShaderPropShadeColor_Step = "_ShadeColor_Step";
         internal const string ShaderProp2nd_ShadeColor_Feather = "_2nd_ShadeColor_Feather";
@@ -170,9 +161,7 @@ namespace UnityEditor.Rendering.Toon {
         internal const string ShaderPropIs_PingPong_Base = "_Is_PingPong_Base";
 
         internal const string ShaderPropIs_ViewShift = "_Is_ViewShift";
-        internal const string ShaderPropIs_BlendBaseColor = "_Is_BlendBaseColor";
         internal const string ShaderPropIs_OutlineTex = "_Is_OutlineTex";
-        internal const string ShaderPropIs_BakedNormal = "_Is_BakedNormal";
         internal const string ShaderPropIs_BLD = "_Is_BLD";
         internal const string ShaderPropInverse_Z_Axis_BLD = "_Inverse_Z_Axis_BLD";
 
@@ -441,8 +430,8 @@ namespace UnityEditor.Rendering.Toon {
             shadingGradeMap = FindProperty(ShaderProp_ShadingGradeMap, props, false);
 
 
-            highColor_Tex = FindProperty(ShaderProp_HighColor_Tex, props);
-            highColor = FindProperty("_HighColor", props);
+            highColor_Tex = FindProperty(ToonConstants.SHADER_PROP_TOON3D_HIGH_COLOR_TEX, props);
+            highColor = FindProperty(ToonConstants.SHADER_PROP_TOON3D_HIGH_COLOR, props);
 
             set_HighColorMask = FindProperty(ShaderProp_Set_HighColorMask, props);
             tweak_HighColorMaskLevel = FindProperty("_Tweak_HighColorMaskLevel", props);
@@ -466,9 +455,9 @@ namespace UnityEditor.Rendering.Toon {
             emissive_Color = FindProperty("_Emissive_Color", props);
 
 
-            outline_Sampler = FindProperty(ShaderProp_Outline_Sampler, props, false);
+            outline_Sampler = FindProperty(ToonConstants.SHADER_PROP_TOON3D_OUTLINE_SAMPLER, props, false);
             outlineTex = FindProperty(ToonConstants.SHADER_PROP_OUTLINE_TEX, props, false);
-            bakedNormal = FindProperty("_BakedNormal", props, false);
+            bakedNormal = FindProperty(ToonConstants.SHADER_PROP_TOON3D_BAKED_NORMAL, props, false);
 
 
             FindTessellationProperties(props);
@@ -818,11 +807,11 @@ namespace UnityEditor.Rendering.Toon {
 
             public static readonly RangeProperty shaderPropBaseColorText = new RangeProperty(
                 label: "Base Color Step", tooltip: "Sets the boundary between the Base Color and the Shade Colors.",
-                propName: ShaderPropBaseColor_Step, defaultValue: 0.5f, min: 0, max: 1);
+                propName: ToonConstants.SHADER_PROP_TOON3D_BASE_COLOR_STEP, defaultValue: 0.5f, min: 0, max: 1);
 
             public static readonly RangeProperty shaderPropBaseFeatherText = new RangeProperty(
                 label: "Base Shading Feather", tooltip: "Feathers the boundary between the Base Color and the Shade Colors..",
-                propName: ShaderPropBaseShade_Feather, defaultValue: 0.0001f, min: 0.0001f, max: 1);
+                propName: ToonConstants.SHADER_PROP_TOON3D_BASE_SHADE_FEATHER, defaultValue: 0.0001f, min: 0.0001f, max: 1);
 
             public static readonly RangeProperty shaderPropShadeColorStepText = new RangeProperty(
                 label: "Shading Color Step", tooltip: "Sets the boundary between the 1st and 2nd Shade Colors. Set this to 0 if no 2nd Shade Color is used.",
@@ -834,12 +823,12 @@ namespace UnityEditor.Rendering.Toon {
 
             public static readonly RangeProperty shaderProp1st_ShadeColor_StepText = new RangeProperty(
                 label: "1st Shade Color Step", tooltip: "Sets the step between the Base color and 1st Shade Color, the same as the BaseColor_Step property..",
-                propName: ShaderProp1st_ShadeColor_Step, defaultValue: 0.5f, min: 0, max: 1);
+                propName: ToonConstants.SHADER_PROP_TOON3D_1ST_SHADE_COLOR_STEP, defaultValue: 0.5f, min: 0, max: 1);
 
             public static readonly RangeProperty shaderProp1st_ShadeColor_FeatherText = new RangeProperty(
                 label: "1st Shade Color Feather",
                 tooltip: "Feathers the boundary between the Base Color and the 1st Shade Color, the same as the Base/Shade_Feather property.",
-                propName: ShaderProp1st_ShadeColor_Feather, defaultValue: 0.0001f, min: 0.0001f, max: 1);
+                propName: ToonConstants.SHADER_PROP_TOON3D_1ST_SHADE_COLOR_FEATHER, defaultValue: 0.0001f, min: 0.0001f, max: 1);
 
             public static readonly RangeProperty shaderProp2nd_ShadeColor_StepText = new RangeProperty(
                 label: "2nd Shade Color Step", tooltip: "Sets the step between the 1st and 2nd Shade Colors, the same as the ShadeColor_Step property.",
@@ -950,17 +939,17 @@ namespace UnityEditor.Rendering.Toon {
 
             public static readonly FloatProperty outlineWidthText = new FloatProperty(label: "Outline Width",
                 tooltip: "Specifies the width of the outline. This value relies on the scale when the model was imported to Unity.",
-                propName: "_Outline_Width", defaultValue: 0);
+                propName: ToonConstants.SHADER_PROP_TOON3D_OUTLINE_WIDTH, defaultValue: 0);
 
             public static readonly FloatProperty farthestDistanceText = new FloatProperty(label: "Farthest Distance to vanish",
                 tooltip:
                 "Specify the furthest distance, where the outline width changes with the distance between the camera and the object. The outline will be zero at this distance.",
-                propName: "_Farthest_Distance", defaultValue: 100);
+                propName: ToonConstants.SHADER_PROP_TOON3D_FARTHEST_DISTANCE, defaultValue: 100);
 
             public static readonly FloatProperty nearestDistanceText = new FloatProperty(label: "Nearest Distance to draw with Outline Width",
                 tooltip:
                 "Specify the closest distance, where the outline width changes with the distance between the camera and the object. At this distance, the outline will be the maximum width set by Outline_Width.",
-                propName: "_Nearest_Distance", defaultValue: 0.5f);
+                propName: ToonConstants.SHADER_PROP_TOON3D_NEAREST_DISTANCE, defaultValue: 0.5f);
 
             public static readonly FloatProperty rotateEmissiveUVText = new FloatProperty(label: "Rotate around UV center",
                 tooltip:
@@ -969,7 +958,7 @@ namespace UnityEditor.Rendering.Toon {
 
             public static readonly FloatProperty offsetZText = new FloatProperty(label: "Offset Outline with Camera Z-axis",
                 tooltip: "Offsets the outline in the depth (Z) direction of the camera.",
-                propName: "_Offset_Z", defaultValue: 0);
+                propName: ToonConstants.SHADER_PROP_TOON3D_OFFSET_Z, defaultValue: 0);
 
             public static readonly FloatProperty colorShiftSpeedText = new FloatProperty(label: "Color Shifting Speed (Time)",
                 tooltip: "Sets the reference speed for color shift. When the value is 1, one cycle should take around 6 seconds.",
@@ -994,7 +983,7 @@ namespace UnityEditor.Rendering.Toon {
 
             public static readonly ColorProperty outlineColorText = new ColorProperty(label: "Outline Color",
                 tooltip: "Specifies the color of outline.",
-                propName: "_Outline_Color", isHDR: false);
+                propName: ToonConstants.SHADER_PROP_TOON3D_OUTLINE_COLOR, isHDR: false);
         }
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -1540,8 +1529,8 @@ namespace UnityEditor.Rendering.Toon {
 
                     //Sharing variables with ShadingGradeMap method.
 
-                    material.SetFloat(ShaderProp1st_ShadeColor_Step, material.GetFloat(ShaderPropBaseColor_Step));
-                    material.SetFloat(ShaderProp1st_ShadeColor_Feather, material.GetFloat(ShaderPropBaseShade_Feather));
+                    material.SetFloat(ToonConstants.SHADER_PROP_TOON3D_1ST_SHADE_COLOR_STEP, material.GetFloat(ToonConstants.SHADER_PROP_TOON3D_BASE_COLOR_STEP));
+                    material.SetFloat(ToonConstants.SHADER_PROP_TOON3D_1ST_SHADE_COLOR_FEATHER, material.GetFloat(ToonConstants.SHADER_PROP_TOON3D_BASE_SHADE_FEATHER));
                     material.SetFloat(ShaderProp2nd_ShadeColor_Step, material.GetFloat(ShaderPropShadeColor_Step));
                     material.SetFloat(ShaderProp2nd_ShadeColor_Feather, material.GetFloat(ShaderProp1st2nd_Shades_Feather));
                 }
@@ -1555,8 +1544,8 @@ namespace UnityEditor.Rendering.Toon {
                     GUI_RangeProperty(material, Styles.shaderProp2nd_ShadeColor_FeatherText);
 
                     //Share variables with DoubleWithFeather method.
-                    material.SetFloat(ShaderPropBaseColor_Step, material.GetFloat(ShaderProp1st_ShadeColor_Step));
-                    material.SetFloat(ShaderPropBaseShade_Feather, material.GetFloat(ShaderProp1st_ShadeColor_Feather));
+                    material.SetFloat(ToonConstants.SHADER_PROP_TOON3D_BASE_COLOR_STEP, material.GetFloat(ToonConstants.SHADER_PROP_TOON3D_1ST_SHADE_COLOR_STEP));
+                    material.SetFloat(ToonConstants.SHADER_PROP_TOON3D_BASE_SHADE_FEATHER, material.GetFloat(ToonConstants.SHADER_PROP_TOON3D_1ST_SHADE_COLOR_FEATHER));
                     material.SetFloat(ShaderPropShadeColor_Step, material.GetFloat(ShaderProp2nd_ShadeColor_Step));
                     material.SetFloat(ShaderProp1st2nd_Shades_Feather, material.GetFloat(ShaderProp2nd_ShadeColor_Feather));
                 }
@@ -2170,7 +2159,7 @@ namespace UnityEditor.Rendering.Toon {
             //
             //Express Shader property [KeywordEnum(NML,POS)] by EumPopup.
             //Load the outline mode settings in the material.
-            int _OutlineMode_Setting = MaterialGetInt(material, ShaderPropOutline);
+            int _OutlineMode_Setting = MaterialGetInt(material, ToonConstants.SHADER_PROP_TOON3D_OUTLINE);
             //Convert it to Enum format and store it in the offlineMode variable.
 
             if ((int)OutlineMode.NormalDirection == _OutlineMode_Setting) {
@@ -2184,13 +2173,13 @@ namespace UnityEditor.Rendering.Toon {
             m_outlineMode = (OutlineMode)EditorGUILayout.EnumPopup(Styles.outlineModeText, m_outlineMode);
             //If the value changes, write to the material.
             if (m_outlineMode == OutlineMode.NormalDirection) {
-                material.SetFloat(ShaderPropOutline, 0);
+                material.SetFloat(ToonConstants.SHADER_PROP_TOON3D_OUTLINE, 0);
                 //The keywords on the UTCS_Outline.cginc side are also toggled around.
                 material.EnableKeyword("_OUTLINE_NML");
                 material.DisableKeyword("_OUTLINE_POS");
             }
             else if (m_outlineMode == OutlineMode.PositionScaling) {
-                material.SetFloat(ShaderPropOutline, 1);
+                material.SetFloat(ToonConstants.SHADER_PROP_TOON3D_OUTLINE, 1);
                 material.EnableKeyword("_OUTLINE_POS");
                 material.DisableKeyword("_OUTLINE_NML");
             }
@@ -2198,7 +2187,7 @@ namespace UnityEditor.Rendering.Toon {
             GUI_FloatProperty(material, Styles.outlineWidthText);
             GUI_ColorProperty(material, Styles.outlineColorText);
 
-            GUI_Toggle(material, Styles.baseColorToOtulineText, ShaderPropIs_BlendBaseColor, MaterialGetInt(material, ShaderPropIs_BlendBaseColor) != 0);
+            GUI_Toggle(material, Styles.baseColorToOtulineText, ToonConstants.SHADER_PROP_TOON3D_IS_BLEND_BASE_COLOR, MaterialGetInt(material, ToonConstants.SHADER_PROP_TOON3D_IS_BLEND_BASE_COLOR) != 0);
 
             m_MaterialEditor.TexturePropertySingleLine(Styles.outlineSamplerText, outline_Sampler);
             GUI_FloatProperty(material, Styles.offsetZText);
@@ -2222,8 +2211,8 @@ namespace UnityEditor.Rendering.Toon {
                     EditorGUI.EndDisabledGroup();
                     EditorGUI.BeginDisabledGroup(m_outlineMode != OutlineMode.NormalDirection);
                     {
-                        var isBackedNormal = GUI_Toggle(material, Styles.bakedNormalForOutlineText, ShaderPropIs_BakedNormal,
-                            MaterialGetInt(material, ShaderPropIs_BakedNormal) != 0);
+                        var isBackedNormal = GUI_Toggle(material, Styles.bakedNormalForOutlineText, ToonConstants.SHADER_PROP_TOON3D_IS_BAKED_NORMAL,
+                            MaterialGetInt(material, ToonConstants.SHADER_PROP_TOON3D_IS_BAKED_NORMAL) != 0);
                         EditorGUI.BeginDisabledGroup(!isBackedNormal);
                         m_MaterialEditor.TexturePropertySingleLine(Styles.bakedNormalOutlineText, bakedNormal);
                         EditorGUI.EndDisabledGroup();
@@ -2272,8 +2261,8 @@ namespace UnityEditor.Rendering.Toon {
 
             GUI_Toggle(material, Styles.lightColorEffectivinessToMatCapText, ShaderPropIs_LightColor_MatCap,
                 MaterialGetInt(material, ShaderPropIs_LightColor_MatCap) != 0);
-            GUI_Toggle(material, Styles.lightColorEffectivinessToOutlineText, ShaderPropIs_LightColor_Outline,
-                MaterialGetInt(material, ShaderPropIs_LightColor_Outline) != 0);
+            GUI_Toggle(material, Styles.lightColorEffectivinessToOutlineText, ToonConstants.SHADER_PROP_TOON3D_IS_LIGHT_COLOR_OUTLINE,
+                MaterialGetInt(material, ToonConstants.SHADER_PROP_TOON3D_IS_LIGHT_COLOR_OUTLINE) != 0);
             EditorGUI.indentLevel--;
             EditorGUILayout.Space();
             GUI_RangeProperty(material, Styles.giIntensityText);
@@ -2292,9 +2281,9 @@ namespace UnityEditor.Rendering.Toon {
                     MaterialSetInt(material, ShaderPropIsLightColor_Base, boolValue);
                     MaterialSetInt(material, ShaderPropIs_LightColor_1st_Shade, boolValue);
                     MaterialSetInt(material, ShaderPropIs_LightColor_2nd_Shade, boolValue);
-                    if (material.HasProperty(ShaderPropOutline)) //If OUTLINE is available.
+                    if (material.HasProperty(ToonConstants.SHADER_PROP_TOON3D_OUTLINE)) //If OUTLINE is available.
                     {
-                        MaterialSetInt(material, ShaderPropIs_LightColor_Outline, boolValue);
+                        MaterialSetInt(material, ToonConstants.SHADER_PROP_TOON3D_IS_LIGHT_COLOR_OUTLINE, boolValue);
                     }
                 }
             }

--- a/com.unity.toonshader/Runtime/Scripts/ToonConstants.cs
+++ b/com.unity.toonshader/Runtime/Scripts/ToonConstants.cs
@@ -95,6 +95,28 @@ internal static class ToonConstants {
     internal const string GBUFFER_PASS_NAME = "GBuffer";
 
     internal const string SHADER_KEYWORD_RP_BUILTIN = "UTS_RP_BUILTIN";
+
+    // Toon 3D (legacy) shader property names (used for upgrade/mapping flows)
+    internal const string SHADER_PROP_TOON3D_BASE_COLOR_STEP = "_BaseColor_Step";
+    internal const string SHADER_PROP_TOON3D_BASE_SHADE_FEATHER = "_BaseShade_Feather";
+    internal const string SHADER_PROP_TOON3D_1ST_SHADE_COLOR_STEP = "_1st_ShadeColor_Step";
+    internal const string SHADER_PROP_TOON3D_1ST_SHADE_COLOR_FEATHER = "_1st_ShadeColor_Feather";
+
+    internal const string SHADER_PROP_TOON3D_HIGH_COLOR = "_HighColor";
+    internal const string SHADER_PROP_TOON3D_HIGH_COLOR_TEX = "_HighColor_Tex";
+
+    internal const string SHADER_PROP_TOON3D_OUTLINE = "_OUTLINE";
+    internal const string SHADER_PROP_TOON3D_OUTLINE_WIDTH = "_Outline_Width";
+    internal const string SHADER_PROP_TOON3D_OUTLINE_SAMPLER = "_Outline_Sampler";
+    internal const string SHADER_PROP_TOON3D_OUTLINE_COLOR = "_Outline_Color";
+    internal const string SHADER_PROP_TOON3D_IS_BLEND_BASE_COLOR = "_Is_BlendBaseColor";
+    internal const string SHADER_PROP_TOON3D_IS_LIGHT_COLOR_OUTLINE = "_Is_LightColor_Outline";
+    internal const string SHADER_PROP_TOON3D_OFFSET_Z = "_Offset_Z";
+    internal const string SHADER_PROP_TOON3D_NEAREST_DISTANCE = "_Nearest_Distance";
+    internal const string SHADER_PROP_TOON3D_FARTHEST_DISTANCE = "_Farthest_Distance";
+
+    internal const string SHADER_PROP_TOON3D_IS_BAKED_NORMAL = "_Is_BakedNormal";
+    internal const string SHADER_PROP_TOON3D_BAKED_NORMAL = "_BakedNormal";
     
 }
 


### PR DESCRIPTION
Remove duplicate shader constants in `UTS3GUI.cs` and `ToonGUI-RenderingPerChannel.cs` by referencing `ToonConstants.cs`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a987a5ad-65fa-43d9-bcda-49804c801519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a987a5ad-65fa-43d9-bcda-49804c801519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

