### PR TITLE
Toon shader lighting utility

### DIFF
--- a/com.unity.toonshader/Runtime/HDRP/Shaders/DoubleShadeWithFeatherMainLight.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/DoubleShadeWithFeatherMainLight.hlsl
@@ -2,6 +2,8 @@
 //nobuyuki@unity3d.com
 //toshiyuki@unity3d.com (Universal RP/HDRP)
 
+#include "../../Shaders/UTSLighting.hlsl"
+
 float3 UTS_MainLight(LightLoopContext lightLoopContext, FragInputs input, float3 mainLihgtDirection, float3 mainLightColor, out float inverseClipping, out float channelOutAlpha, out UTSData utsData)
 {
     channelOutAlpha = 1.0f;
@@ -292,7 +294,7 @@ float3 UTS_MainLight(LightLoopContext lightLoopContext, FragInputs input, float3
     //
     //v.2.0.6: GI_Intensity with Intensity Multiplier Filter
     float3 envLightColor = saturate(SampleBakedGI_UTS(posInput.positionWS, utsData.normalDirection, input.texCoord1.xy, input.texCoord2.xy, true));
-    float envLightIntensity = saturate(0.299 * envLightColor.r + 0.587 * envLightColor.g + 0.114 * envLightColor.b);
+    float envLightIntensity = saturate(UTS_CalculateLightColorIntensity(envLightColor));
 
     finalColor = SATURATE_IF_SDR(finalColor) + (envLightColor * envLightIntensity * _GI_Intensity * smoothstep(1, 0, envLightIntensity / 2)) + emissive;
 

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/DoubleShadeWithFeatherMainLight.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/DoubleShadeWithFeatherMainLight.hlsl
@@ -294,7 +294,7 @@ float3 UTS_MainLight(LightLoopContext lightLoopContext, FragInputs input, float3
     //
     //v.2.0.6: GI_Intensity with Intensity Multiplier Filter
     float3 envLightColor = saturate(SampleBakedGI_UTS(posInput.positionWS, utsData.normalDirection, input.texCoord1.xy, input.texCoord2.xy, true));
-    float envLightIntensity = saturate(UTS_CalculateLightColorIntensity(envLightColor));
+    float envLightIntensity = saturate(Intensity(envLightColor));
 
     finalColor = SATURATE_IF_SDR(finalColor) + (envLightColor * envLightIntensity * _GI_Intensity * smoothstep(1, 0, envLightIntensity / 2)) + emissive;
 

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/DoubleShadeWithFeatherOtherLight.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/DoubleShadeWithFeatherOtherLight.hlsl
@@ -2,6 +2,8 @@
 //nobuyuki@unity3d.com
 //toshiyuki@unity3d.com (Universal RP/HDRP)
 
+#include "../../Shaders/UTSLighting.hlsl"
+
 float3 UTS_OtherLights(FragInputs input, float3 i_normalDir,
     float3 additionalLightColor, float3 lightDirection, float notDirectional, out float channelOutAlpha)
 {
@@ -39,7 +41,7 @@ float3 UTS_OtherLights(FragInputs input, float3 i_normalDir,
 
     //v.2.0.5:
     float3 addPassLightColor = (0.5 * dot(lerp(i_normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) + 0.5) * additionalLightColor.rgb;
-    float  pureIntencity = max(0.001, (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b));
+    float  pureIntencity = max(0.001, UTS_CalculateLightColorIntensity(additionalLightColor));
     float3 lightColor = max(float3(0.0,0.0,0.0), lerp(addPassLightColor, lerp(float3(0.0,0.0,0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional), _Is_Filter_LightColor));
     float3 halfDirection = normalize(viewDirection + lightDirection); // has to be recalced here.
     //v.2.0.5:
@@ -47,7 +49,7 @@ float3 UTS_OtherLights(FragInputs input, float3 i_normalDir,
     _ShadeColor_Step = saturate(_ShadeColor_Step + _StepOffset);
     //
     //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
-    float _LightIntensity = lerp(0, (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b), notDirectional);
+    float _LightIntensity = lerp(0, UTS_CalculateLightColorIntensity(additionalLightColor), notDirectional);
     //v.2.0.5: Filtering the high intensity zone of PointLights
     float3 Set_LightColor = lightColor;
     //

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/DoubleShadeWithFeatherOtherLight.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/DoubleShadeWithFeatherOtherLight.hlsl
@@ -41,7 +41,7 @@ float3 UTS_OtherLights(FragInputs input, float3 i_normalDir,
 
     //v.2.0.5:
     float3 addPassLightColor = (0.5 * dot(lerp(i_normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) + 0.5) * additionalLightColor.rgb;
-    float  pureIntencity = max(0.001, UTS_CalculateLightColorIntensity(additionalLightColor));
+    float  pureIntencity = max(0.001, Intensity(additionalLightColor));
     float3 lightColor = max(float3(0.0,0.0,0.0), lerp(addPassLightColor, lerp(float3(0.0,0.0,0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional), _Is_Filter_LightColor));
     float3 halfDirection = normalize(viewDirection + lightDirection); // has to be recalced here.
     //v.2.0.5:
@@ -49,7 +49,7 @@ float3 UTS_OtherLights(FragInputs input, float3 i_normalDir,
     _ShadeColor_Step = saturate(_ShadeColor_Step + _StepOffset);
     //
     //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
-    float _LightIntensity = lerp(0, UTS_CalculateLightColorIntensity(additionalLightColor), notDirectional);
+    float _LightIntensity = lerp(0, Intensity(additionalLightColor), notDirectional);
     //v.2.0.5: Filtering the high intensity zone of PointLights
     float3 Set_LightColor = lightColor;
     //

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/HDRPToonOutline.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/HDRPToonOutline.hlsl
@@ -2,6 +2,8 @@
 //nobuyuki@unity3d.com
 //toshiyuki@unity3d.com (Universal RP/HDRP)
 
+#include "../../Shaders/UTSLighting.hlsl"
+
 
 #undef unity_ObjectToWorld
 #undef unity_WorldToObject
@@ -157,7 +159,7 @@ void Frag(PackedVaryingsToPS packedInput,
     float3 ambientSkyColor = envLightSource_SkyboxIntensity.rgb>0.0 ? envLightSource_SkyboxIntensity*_Unlit_Intensity : envLightSource_GradientEquator*_Unlit_Intensity;
     //
     float3 lightColor = _LightColor0.rgb >0.05 ? _LightColor0.rgb : ambientSkyColor.rgb;
-    float lightColorIntensity = (0.299*lightColor.r + 0.587*lightColor.g + 0.114*lightColor.b);
+    float lightColorIntensity = UTS_CalculateLightColorIntensity(lightColor);
     lightColor = lightColorIntensity<1 ? lightColor : lightColor/lightColorIntensity;
     lightColor = lerp(half3(1.0,1.0,1.0), lightColor, _Is_LightColor_Outline);
 

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/HDRPToonOutline.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/HDRPToonOutline.hlsl
@@ -159,7 +159,7 @@ void Frag(PackedVaryingsToPS packedInput,
     float3 ambientSkyColor = envLightSource_SkyboxIntensity.rgb>0.0 ? envLightSource_SkyboxIntensity*_Unlit_Intensity : envLightSource_GradientEquator*_Unlit_Intensity;
     //
     float3 lightColor = _LightColor0.rgb >0.05 ? _LightColor0.rgb : ambientSkyColor.rgb;
-    float lightColorIntensity = UTS_CalculateLightColorIntensity(lightColor);
+    float lightColorIntensity = Intensity(lightColor);
     lightColor = lightColorIntensity<1 ? lightColor : lightColor/lightColorIntensity;
     lightColor = lerp(half3(1.0,1.0,1.0), lightColor, _Is_LightColor_Outline);
 

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/ShadingGrademapMainLight.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/ShadingGrademapMainLight.hlsl
@@ -393,7 +393,7 @@ float3 UTS_MainLightShadingGrademap(LightLoopContext lightLoopContext, FragInput
 
     //v.2.0.6: GI_Intensity with Intensity Multiplier Filter
     float3 envLightColor = saturate(SampleBakedGI_UTS(posInput.positionWS, utsData.normalDirection, input.texCoord1.xy, input.texCoord2.xy, true));
-    float envLightIntensity = saturate(UTS_CalculateLightColorIntensity(envLightColor));
+    float envLightIntensity = saturate(Intensity(envLightColor));
 
     finalColor = SATURATE_IF_SDR(finalColor) + (envLightColor * envLightIntensity * _GI_Intensity * smoothstep(1, 0, envLightIntensity / 2)) + emissive;
 

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/ShadingGrademapMainLight.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/ShadingGrademapMainLight.hlsl
@@ -2,6 +2,8 @@
 //nobuyuki@unity3d.com
 //toshiyuki@unity3d.com (Universal RP/HDRP)
 
+#include "../../Shaders/UTSLighting.hlsl"
+
 
 #ifndef DirectionalShadowType
 # if (SHADEROPTIONS_RAYTRACING && (defined(SHADER_API_D3D11) || defined(SHADER_API_D3D12)) && !defined(SHADER_API_XBOXONE) && !defined(SHADER_API_PSSL))
@@ -391,7 +393,7 @@ float3 UTS_MainLightShadingGrademap(LightLoopContext lightLoopContext, FragInput
 
     //v.2.0.6: GI_Intensity with Intensity Multiplier Filter
     float3 envLightColor = saturate(SampleBakedGI_UTS(posInput.positionWS, utsData.normalDirection, input.texCoord1.xy, input.texCoord2.xy, true));
-    float envLightIntensity = saturate(0.299 * envLightColor.r + 0.587 * envLightColor.g + 0.114 * envLightColor.b);
+    float envLightIntensity = saturate(UTS_CalculateLightColorIntensity(envLightColor));
 
     finalColor = SATURATE_IF_SDR(finalColor) + (envLightColor * envLightIntensity * _GI_Intensity * smoothstep(1, 0, envLightIntensity / 2)) + emissive;
 

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/ShadingGrademapOtherLight.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/ShadingGrademapOtherLight.hlsl
@@ -2,6 +2,8 @@
 //nobuyuki@unity3d.com
 //toshiyuki@unity3d.com (Universal RP/HDRP)
 
+#include "../../Shaders/UTSLighting.hlsl"
+
 float3 UTS_OtherLightsShadingGrademap(FragInputs input, float3 i_normalDir,
     float3 additionalLightColor, float3 lightDirection, float notDirectional, out float channelOutAlpha)
 {
@@ -41,7 +43,7 @@ float3 UTS_OtherLightsShadingGrademap(FragInputs input, float3 i_normalDir,
 
     //v.2.0.5:
     float3 addPassLightColor = (0.5 * dot(lerp(i_normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) + 0.5) * additionalLightColor.rgb;
-    float  pureIntencity = max(0.001, (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b));
+    float  pureIntencity = max(0.001, UTS_CalculateLightColorIntensity(additionalLightColor));
     float3 lightColor = max(float3(0.0,0.0,0.0), lerp(addPassLightColor, lerp(float3(0.0,0.0,0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional), _Is_Filter_LightColor));
     float3 halfDirection = normalize(viewDirection + lightDirection); // has to be recalced here.
     //v.2.0.5:
@@ -50,7 +52,7 @@ float3 UTS_OtherLightsShadingGrademap(FragInputs input, float3 i_normalDir,
     _2nd_ShadeColor_Step = saturate(_2nd_ShadeColor_Step + _StepOffset);
     //
     //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
-    float _LightIntensity = lerp(0, (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b), notDirectional);
+    float _LightIntensity = lerp(0, UTS_CalculateLightColorIntensity(additionalLightColor), notDirectional);
     //v.2.0.5: Filtering the high intensity zone of PointLights
     float3 Set_LightColor = lightColor;
     //

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/ShadingGrademapOtherLight.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/ShadingGrademapOtherLight.hlsl
@@ -43,7 +43,7 @@ float3 UTS_OtherLightsShadingGrademap(FragInputs input, float3 i_normalDir,
 
     //v.2.0.5:
     float3 addPassLightColor = (0.5 * dot(lerp(i_normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) + 0.5) * additionalLightColor.rgb;
-    float  pureIntencity = max(0.001, UTS_CalculateLightColorIntensity(additionalLightColor));
+    float  pureIntencity = max(0.001, Intensity(additionalLightColor));
     float3 lightColor = max(float3(0.0,0.0,0.0), lerp(addPassLightColor, lerp(float3(0.0,0.0,0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional), _Is_Filter_LightColor));
     float3 halfDirection = normalize(viewDirection + lightDirection); // has to be recalced here.
     //v.2.0.5:
@@ -52,7 +52,7 @@ float3 UTS_OtherLightsShadingGrademap(FragInputs input, float3 i_normalDir,
     _2nd_ShadeColor_Step = saturate(_2nd_ShadeColor_Step + _StepOffset);
     //
     //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
-    float _LightIntensity = lerp(0, UTS_CalculateLightColorIntensity(additionalLightColor), notDirectional);
+    float _LightIntensity = lerp(0, Intensity(additionalLightColor), notDirectional);
     //v.2.0.5: Filtering the high intensity zone of PointLights
     float3 Set_LightColor = lightColor;
     //

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_DoubleShadeWithFeather.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_DoubleShadeWithFeather.cginc
@@ -139,7 +139,7 @@ struct VertexOutput {
                 float3 lightDirection = normalize(lerp(_WorldSpaceLightPos0.xyz, _WorldSpaceLightPos0.xyz - i.posWorld.xyz,_WorldSpaceLightPos0.w));
                 //v.2.0.5:
                 float3 addPassLightColor = (0.5*dot(lerp( i.normalDir, normalDirection, _Is_NormalMapToBase ), lightDirection)+0.5) * _LightColor0.rgb * attenuation;
-                float pureIntencity = max(0.001, UTS_CalculateLightColorIntensity(_LightColor0.rgb));
+                float pureIntencity = max(0.001, Intensity(_LightColor0.rgb));
                 float3 lightColor = max(float3(0,0,0), lerp(addPassLightColor, lerp(float3(0,0,0),min(addPassLightColor,addPassLightColor/pureIntencity),_WorldSpaceLightPos0.w),_Is_Filter_LightColor));
 #endif
 ////// Lighting:
@@ -250,7 +250,7 @@ struct VertexOutput {
                 //
                 //v.2.0.6: GI_Intensity with Intensity Multiplier Filter
                 float3 envLightColor = DecodeLightProbe(normalDirection) < float3(1,1,1) ? DecodeLightProbe(normalDirection) : float3(1,1,1);
-                float envLightIntensity = min(UTS_CalculateLightColorIntensity(envLightColor), 1);
+                float envLightIntensity = min(Intensity(envLightColor), 1);
 //v.2.0.7
 #ifdef _EMISSIVE_SIMPLE
                 float4 _Emissive_Tex_var = tex2D(_Emissive_Tex,TRANSFORM_TEX(Set_UV0, _Emissive_Tex));
@@ -298,7 +298,7 @@ struct VertexOutput {
                 _ShadeColor_Step = saturate(_ShadeColor_Step + _StepOffset);
                 //
                 //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
-                float _LightIntensity = lerp(0, UTS_CalculateLightColorIntensity(_LightColor0.rgb) * attenuation, _WorldSpaceLightPos0.w);
+                float _LightIntensity = lerp(0, Intensity(_LightColor0.rgb) * attenuation, _WorldSpaceLightPos0.w);
                 //v.2.0.5: Filtering the high intensity zone of PointLights
                 float3 Set_LightColor = lightColor;
                 //

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_DoubleShadeWithFeather.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_DoubleShadeWithFeather.cginc
@@ -35,6 +35,7 @@ struct VertexOutput {
 
 #include "UCTS_Light.cginc"
 #include "UCTS_Input.cginc"
+#include "../../Shaders/UTSLighting.hlsl"
 
             //function to rotate the UV: RotateUV()
             //float2 rotatedUV = RotateUV(i.uv0, (_angular_Verocity*3.141592654), float2(0.5, 0.5), _Time.g);
@@ -138,7 +139,7 @@ struct VertexOutput {
                 float3 lightDirection = normalize(lerp(_WorldSpaceLightPos0.xyz, _WorldSpaceLightPos0.xyz - i.posWorld.xyz,_WorldSpaceLightPos0.w));
                 //v.2.0.5:
                 float3 addPassLightColor = (0.5*dot(lerp( i.normalDir, normalDirection, _Is_NormalMapToBase ), lightDirection)+0.5) * _LightColor0.rgb * attenuation;
-                float pureIntencity = max(0.001,(0.299*_LightColor0.r + 0.587*_LightColor0.g + 0.114*_LightColor0.b));
+                float pureIntencity = max(0.001, UTS_CalculateLightColorIntensity(_LightColor0.rgb));
                 float3 lightColor = max(float3(0,0,0), lerp(addPassLightColor, lerp(float3(0,0,0),min(addPassLightColor,addPassLightColor/pureIntencity),_WorldSpaceLightPos0.w),_Is_Filter_LightColor));
 #endif
 ////// Lighting:
@@ -249,7 +250,7 @@ struct VertexOutput {
                 //
                 //v.2.0.6: GI_Intensity with Intensity Multiplier Filter
                 float3 envLightColor = DecodeLightProbe(normalDirection) < float3(1,1,1) ? DecodeLightProbe(normalDirection) : float3(1,1,1);
-                float envLightIntensity = 0.299*envLightColor.r + 0.587*envLightColor.g + 0.114*envLightColor.b <1 ? (0.299*envLightColor.r + 0.587*envLightColor.g + 0.114*envLightColor.b) : 1;
+                float envLightIntensity = min(UTS_CalculateLightColorIntensity(envLightColor), 1);
 //v.2.0.7
 #ifdef _EMISSIVE_SIMPLE
                 float4 _Emissive_Tex_var = tex2D(_Emissive_Tex,TRANSFORM_TEX(Set_UV0, _Emissive_Tex));
@@ -297,7 +298,7 @@ struct VertexOutput {
                 _ShadeColor_Step = saturate(_ShadeColor_Step + _StepOffset);
                 //
                 //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
-                float _LightIntensity = lerp(0,(0.299*_LightColor0.r + 0.587*_LightColor0.g + 0.114*_LightColor0.b)*attenuation,_WorldSpaceLightPos0.w) ;
+                float _LightIntensity = lerp(0, UTS_CalculateLightColorIntensity(_LightColor0.rgb) * attenuation, _WorldSpaceLightPos0.w);
                 //v.2.0.5: Filtering the high intensity zone of PointLights
                 float3 Set_LightColor = lightColor;
                 //

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline.cginc
@@ -82,7 +82,7 @@
                 float3 ambientSkyColor = envLightSource_SkyboxIntensity.rgb>0.0 ? envLightSource_SkyboxIntensity*_Unlit_Intensity : envLightSource_GradientEquator*_Unlit_Intensity;
                 //
                 float3 lightColor = _LightColor0.rgb >0.05 ? _LightColor0.rgb : ambientSkyColor.rgb;
-                float lightColorIntensity = UTS_CalculateLightColorIntensity(lightColor);
+                float lightColorIntensity = Intensity(lightColor);
                 lightColor = lightColorIntensity<1 ? lightColor : lightColor/lightColorIntensity;
                 lightColor = lerp(half3(1.0,1.0,1.0), lightColor, _Is_LightColor_Outline);
                 float2 Set_UV0 = i.uv0;

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline.cginc
@@ -4,6 +4,7 @@
 //
 
 #include "UCTS_Input.cginc"
+#include "../../Shaders/UTSLighting.hlsl"
 
             uniform float4 _LightColor0;
 
@@ -81,7 +82,7 @@
                 float3 ambientSkyColor = envLightSource_SkyboxIntensity.rgb>0.0 ? envLightSource_SkyboxIntensity*_Unlit_Intensity : envLightSource_GradientEquator*_Unlit_Intensity;
                 //
                 float3 lightColor = _LightColor0.rgb >0.05 ? _LightColor0.rgb : ambientSkyColor.rgb;
-                float lightColorIntensity = (0.299*lightColor.r + 0.587*lightColor.g + 0.114*lightColor.b);
+                float lightColorIntensity = UTS_CalculateLightColorIntensity(lightColor);
                 lightColor = lightColorIntensity<1 ? lightColor : lightColor/lightColorIntensity;
                 lightColor = lerp(half3(1.0,1.0,1.0), lightColor, _Is_LightColor_Outline);
                 float2 Set_UV0 = i.uv0;

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline_Tess.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline_Tess.cginc
@@ -101,7 +101,7 @@ struct VertexOutput {
                 float3 ambientSkyColor = envLightSource_SkyboxIntensity.rgb>0.0 ? envLightSource_SkyboxIntensity*_Unlit_Intensity : envLightSource_GradientEquator*_Unlit_Intensity;
                 //
                 float3 lightColor = _LightColor0.rgb >0.05 ? _LightColor0.rgb : ambientSkyColor.rgb;
-                float lightColorIntensity = UTS_CalculateLightColorIntensity(lightColor);
+                float lightColorIntensity = Intensity(lightColor);
                 lightColor = lightColorIntensity<1 ? lightColor : lightColor/lightColorIntensity;
                 lightColor = lerp(half3(1.0,1.0,1.0), lightColor, _Is_LightColor_Outline);
                 float2 Set_UV0 = i.uv0;

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline_Tess.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline_Tess.cginc
@@ -27,6 +27,7 @@ struct VertexOutput {
 
 //---------------------------------------------------------------------------------------------------------------------
 #include "UCTS_Input.cginc"
+#include "../../Shaders/UTSLighting.hlsl"
 #ifdef TESSELLATION_ON
             #include "UCTS_Tess.cginc"
 #endif
@@ -100,7 +101,7 @@ struct VertexOutput {
                 float3 ambientSkyColor = envLightSource_SkyboxIntensity.rgb>0.0 ? envLightSource_SkyboxIntensity*_Unlit_Intensity : envLightSource_GradientEquator*_Unlit_Intensity;
                 //
                 float3 lightColor = _LightColor0.rgb >0.05 ? _LightColor0.rgb : ambientSkyColor.rgb;
-                float lightColorIntensity = (0.299*lightColor.r + 0.587*lightColor.g + 0.114*lightColor.b);
+                float lightColorIntensity = UTS_CalculateLightColorIntensity(lightColor);
                 lightColor = lightColorIntensity<1 ? lightColor : lightColor/lightColorIntensity;
                 lightColor = lerp(half3(1.0,1.0,1.0), lightColor, _Is_LightColor_Outline);
                 float2 Set_UV0 = i.uv0;

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_ShadingGradeMap.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_ShadingGradeMap.cginc
@@ -45,6 +45,7 @@ struct VertexOutput {
 
 #include "UCTS_Light.cginc"
 #include "UCTS_Input.cginc"
+#include "../../Shaders/UTSLighting.hlsl"
             //function to rotate the UV: RotateUV()
             //float2 rotatedUV = RotateUV(i.uv0, (_angular_Verocity*3.141592654), float2(0.5, 0.5), _Time.g);
             float2 RotateUV(float2 _uv, float _radian, float2 _piv, float _time)
@@ -142,7 +143,7 @@ struct VertexOutput {
                 float3 lightDirection = normalize(lerp(_WorldSpaceLightPos0.xyz, _WorldSpaceLightPos0.xyz - i.posWorld.xyz,_WorldSpaceLightPos0.w));
                 //v.2.0.5:
                 float3 addPassLightColor = (0.5*dot(lerp( i.normalDir, normalDirection, _Is_NormalMapToBase ), lightDirection)+0.5) * _LightColor0.rgb * attenuation;
-                float pureIntencity = max(0.001,(0.299*_LightColor0.r + 0.587*_LightColor0.g + 0.114*_LightColor0.b));
+                float pureIntencity = max(0.001, UTS_CalculateLightColorIntensity(_LightColor0.rgb));
                 float3 lightColor = max(float3(0,0,0), lerp(addPassLightColor, lerp(float3(0,0,0),min(addPassLightColor,addPassLightColor/pureIntencity),_WorldSpaceLightPos0.w),_Is_Filter_LightColor));
 #endif
 ////// Lighting:
@@ -315,7 +316,7 @@ struct VertexOutput {
 //
                 //v.2.0.6: GI_Intensity with Intensity Multiplier Filter
                 float3 envLightColor = DecodeLightProbe(normalDirection) < float3(1,1,1) ? DecodeLightProbe(normalDirection) : float3(1,1,1);
-                float envLightIntensity = 0.299*envLightColor.r + 0.587*envLightColor.g + 0.114*envLightColor.b <1 ? (0.299*envLightColor.r + 0.587*envLightColor.g + 0.114*envLightColor.b) : 1;
+                float envLightIntensity = min(UTS_CalculateLightColorIntensity(envLightColor), 1);
                 //Final Composition
                 finalColor =  saturate(finalColor) + (envLightColor*envLightIntensity*_GI_Intensity*smoothstep(1,0,envLightIntensity/2)) + emissive;
 
@@ -326,7 +327,7 @@ struct VertexOutput {
                 _2nd_ShadeColor_Step = saturate(_2nd_ShadeColor_Step + _StepOffset);
                 //
                 //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
-                float _LightIntensity = lerp(0,(0.299*_LightColor0.r + 0.587*_LightColor0.g + 0.114*_LightColor0.b)*attenuation,_WorldSpaceLightPos0.w) ;
+                float _LightIntensity = lerp(0, UTS_CalculateLightColorIntensity(_LightColor0.rgb) * attenuation, _WorldSpaceLightPos0.w);
                 //v.2.0.5: Filtering the high intensity zone of PointLights
                 float3 Set_LightColor = lightColor;
                 //

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_ShadingGradeMap.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_ShadingGradeMap.cginc
@@ -143,7 +143,7 @@ struct VertexOutput {
                 float3 lightDirection = normalize(lerp(_WorldSpaceLightPos0.xyz, _WorldSpaceLightPos0.xyz - i.posWorld.xyz,_WorldSpaceLightPos0.w));
                 //v.2.0.5:
                 float3 addPassLightColor = (0.5*dot(lerp( i.normalDir, normalDirection, _Is_NormalMapToBase ), lightDirection)+0.5) * _LightColor0.rgb * attenuation;
-                float pureIntencity = max(0.001, UTS_CalculateLightColorIntensity(_LightColor0.rgb));
+                float pureIntencity = max(0.001, Intensity(_LightColor0.rgb));
                 float3 lightColor = max(float3(0,0,0), lerp(addPassLightColor, lerp(float3(0,0,0),min(addPassLightColor,addPassLightColor/pureIntencity),_WorldSpaceLightPos0.w),_Is_Filter_LightColor));
 #endif
 ////// Lighting:
@@ -316,7 +316,7 @@ struct VertexOutput {
 //
                 //v.2.0.6: GI_Intensity with Intensity Multiplier Filter
                 float3 envLightColor = DecodeLightProbe(normalDirection) < float3(1,1,1) ? DecodeLightProbe(normalDirection) : float3(1,1,1);
-                float envLightIntensity = min(UTS_CalculateLightColorIntensity(envLightColor), 1);
+                float envLightIntensity = min(Intensity(envLightColor), 1);
                 //Final Composition
                 finalColor =  saturate(finalColor) + (envLightColor*envLightIntensity*_GI_Intensity*smoothstep(1,0,envLightIntensity/2)) + emissive;
 
@@ -327,7 +327,7 @@ struct VertexOutput {
                 _2nd_ShadeColor_Step = saturate(_2nd_ShadeColor_Step + _StepOffset);
                 //
                 //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
-                float _LightIntensity = lerp(0, UTS_CalculateLightColorIntensity(_LightColor0.rgb) * attenuation, _WorldSpaceLightPos0.w);
+                float _LightIntensity = lerp(0, Intensity(_LightColor0.rgb) * attenuation, _WorldSpaceLightPos0.w);
                 //v.2.0.5: Filtering the high intensity zone of PointLights
                 float3 Set_LightColor = lightColor;
                 //

--- a/com.unity.toonshader/Runtime/Shaders/UTSLighting.hlsl
+++ b/com.unity.toonshader/Runtime/Shaders/UTSLighting.hlsl
@@ -1,7 +1,7 @@
 #ifndef UTS_LIGHTING_INCLUDED
 #define UTS_LIGHTING_INCLUDED
 
-inline float UTS_CalculateLightColorIntensity(float3 lightColor)
+inline float Intensity(float3 lightColor)
 {
     return 0.299 * lightColor.r + 0.587 * lightColor.g + 0.114 * lightColor.b;
 }

--- a/com.unity.toonshader/Runtime/Shaders/UTSLighting.hlsl
+++ b/com.unity.toonshader/Runtime/Shaders/UTSLighting.hlsl
@@ -1,0 +1,9 @@
+#ifndef UTS_LIGHTING_INCLUDED
+#define UTS_LIGHTING_INCLUDED
+
+inline float UTS_CalculateLightColorIntensity(float3 lightColor)
+{
+    return 0.299 * lightColor.r + 0.587 * lightColor.g + 0.114 * lightColor.b;
+}
+
+#endif // UTS_LIGHTING_INCLUDED

--- a/com.unity.toonshader/Runtime/Shaders/UTSLighting.hlsl.meta
+++ b/com.unity.toonshader/Runtime/Shaders/UTSLighting.hlsl.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: 0777ab2a6ee64dbfa9ea148947d2a8e0
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+fileFormatVersion: 2
+guid: 0777ab2a6ee64dbfa9ea148947d2a8e0
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -1,4 +1,6 @@
 
+#include "../../Shaders/UTSLighting.hlsl"
+
 void ToonShading(
     const float4 firstShadePosTex, const float4 secondShadePosTex, const float3 highlightTex, 
     const float3 highlightMaskTex,
@@ -340,9 +342,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
     float3 envLightColor = envColor.rgb;
 
-    float envLightIntensity = 0.299 * envLightColor.r + 0.587 * envLightColor.g + 0.114 * envLightColor.b < 1
-                                  ? (0.299 * envLightColor.r + 0.587 * envLightColor.g + 0.114 * envLightColor.b)
-                                  : 1;
+    float envLightIntensity = min(UTS_CalculateLightColorIntensity(envLightColor), 1);
 
 
     float3 pointLightColor = 0;
@@ -374,14 +374,14 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
             float3 addPassLightColor = (0.5 * dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) +
                 0.5) * additionalLightColor.rgb;
             float pureIntencity = max(0.001,
-                (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b));
+                UTS_CalculateLightColorIntensity(additionalLightColor));
             float3 lightColor = max(float3(0.0, 0.0, 0.0), lerp(addPassLightColor,
                 lerp(float3(0.0, 0.0, 0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional),
                 _Is_Filter_LightColor));
 
             //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
             float _LightIntensity = lerp(0,
-                (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b),
+                UTS_CalculateLightColorIntensity(additionalLightColor),
                 notDirectional);
                     
             float lightIntensity = _LightIntensity;
@@ -438,14 +438,14 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
         float3 addPassLightColor = (0.5 * dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) +
             0.5) * additionalLightColor.rgb;
         float pureIntencity = max(0.001,
-            (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b));
+            UTS_CalculateLightColorIntensity(additionalLightColor));
         float3 lightColor = max(float3(0.0, 0.0, 0.0), lerp(addPassLightColor,
             lerp(float3(0.0, 0.0, 0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional),
             _Is_Filter_LightColor));
 
         //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
         float _LightIntensity = lerp(0,
-            (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b),
+            UTS_CalculateLightColorIntensity(additionalLightColor),
             notDirectional);
             
         float lightIntensity = _LightIntensity;

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -342,7 +342,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
     float3 envLightColor = envColor.rgb;
 
-    float envLightIntensity = min(UTS_CalculateLightColorIntensity(envLightColor), 1);
+    float envLightIntensity = min(Intensity(envLightColor), 1);
 
 
     float3 pointLightColor = 0;
@@ -374,14 +374,14 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
             float3 addPassLightColor = (0.5 * dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) +
                 0.5) * additionalLightColor.rgb;
             float pureIntencity = max(0.001,
-                UTS_CalculateLightColorIntensity(additionalLightColor));
+                Intensity(additionalLightColor));
             float3 lightColor = max(float3(0.0, 0.0, 0.0), lerp(addPassLightColor,
                 lerp(float3(0.0, 0.0, 0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional),
                 _Is_Filter_LightColor));
 
             //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
             float _LightIntensity = lerp(0,
-                UTS_CalculateLightColorIntensity(additionalLightColor),
+                Intensity(additionalLightColor),
                 notDirectional);
                     
             float lightIntensity = _LightIntensity;
@@ -438,14 +438,14 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
         float3 addPassLightColor = (0.5 * dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) +
             0.5) * additionalLightColor.rgb;
         float pureIntencity = max(0.001,
-            UTS_CalculateLightColorIntensity(additionalLightColor));
+            Intensity(additionalLightColor));
         float3 lightColor = max(float3(0.0, 0.0, 0.0), lerp(addPassLightColor,
             lerp(float3(0.0, 0.0, 0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional),
             _Is_Filter_LightColor));
 
         //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
         float _LightIntensity = lerp(0,
-            UTS_CalculateLightColorIntensity(additionalLightColor),
+            Intensity(additionalLightColor),
             notDirectional);
             
         float lightIntensity = _LightIntensity;

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -423,7 +423,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
     float3 envLightColor = envColor.rgb;
 
-    float envLightIntensity = min(UTS_CalculateLightColorIntensity(envLightColor), 1);
+    float envLightIntensity = min(Intensity(envLightColor), 1);
 
 
     float3 pointLightColor = 0;
@@ -452,7 +452,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
             float3 addPassLightColor = (0.5 * dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) +
                 0.5) * additionalLightColor.rgb;
             float pureIntencity = max(0.001,
-                UTS_CalculateLightColorIntensity(additionalLightColor));
+                Intensity(additionalLightColor));
             float3 lightColor = max(float3(0.0, 0.0, 0.0), lerp(addPassLightColor,
                 lerp(float3(0.0, 0.0, 0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional),
                 _Is_Filter_LightColor));
@@ -460,7 +460,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
             //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
             float _LightIntensity = lerp(0,
-                UTS_CalculateLightColorIntensity(additionalLightColor),
+                Intensity(additionalLightColor),
                 notDirectional);
             
             float lightIntensity = _LightIntensity;
@@ -519,7 +519,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
         float3 addPassLightColor = (0.5 * dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) +
             0.5) * additionalLightColor.rgb;
         float pureIntencity = max(0.001,
-            UTS_CalculateLightColorIntensity(additionalLightColor));
+            Intensity(additionalLightColor));
         float3 lightColor = max(float3(0.0, 0.0, 0.0), lerp(addPassLightColor,
             lerp(float3(0.0, 0.0, 0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional),
             _Is_Filter_LightColor));
@@ -527,7 +527,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
         //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
         float _LightIntensity = lerp(0,
-            UTS_CalculateLightColorIntensity(additionalLightColor),
+            Intensity(additionalLightColor),
             notDirectional);
 
         float lightIntensity = _LightIntensity;

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -1,3 +1,5 @@
+#include "../../Shaders/UTSLighting.hlsl"
+
 void ToonShadingSG(
     const float3 highlightTex, const float3 highlightMaskTex,
     const float3 lightColor, const float lightIntensity, const float tweakShadows, 
@@ -421,9 +423,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
     float3 envLightColor = envColor.rgb;
 
-    float envLightIntensity = 0.299 * envLightColor.r + 0.587 * envLightColor.g + 0.114 * envLightColor.b < 1
-                                  ? (0.299 * envLightColor.r + 0.587 * envLightColor.g + 0.114 * envLightColor.b)
-                                  : 1;
+    float envLightIntensity = min(UTS_CalculateLightColorIntensity(envLightColor), 1);
 
 
     float3 pointLightColor = 0;
@@ -452,7 +452,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
             float3 addPassLightColor = (0.5 * dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) +
                 0.5) * additionalLightColor.rgb;
             float pureIntencity = max(0.001,
-                (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b));
+                UTS_CalculateLightColorIntensity(additionalLightColor));
             float3 lightColor = max(float3(0.0, 0.0, 0.0), lerp(addPassLightColor,
                 lerp(float3(0.0, 0.0, 0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional),
                 _Is_Filter_LightColor));
@@ -460,7 +460,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
             //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
             float _LightIntensity = lerp(0,
-                (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b),
+                UTS_CalculateLightColorIntensity(additionalLightColor),
                 notDirectional);
             
             float lightIntensity = _LightIntensity;
@@ -519,7 +519,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
         float3 addPassLightColor = (0.5 * dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) +
             0.5) * additionalLightColor.rgb;
         float pureIntencity = max(0.001,
-            (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b));
+            UTS_CalculateLightColorIntensity(additionalLightColor));
         float3 lightColor = max(float3(0.0, 0.0, 0.0), lerp(addPassLightColor,
             lerp(float3(0.0, 0.0, 0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional),
             _Is_Filter_LightColor));
@@ -527,7 +527,7 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
         //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
         float _LightIntensity = lerp(0,
-            (0.299 * additionalLightColor.r + 0.587 * additionalLightColor.g + 0.114 * additionalLightColor.b),
+            UTS_CalculateLightColorIntensity(additionalLightColor),
             notDirectional);
 
         float lightIntensity = _LightIntensity;

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
@@ -1,3 +1,5 @@
+#include "../../Shaders/UTSLighting.hlsl"
+
 uniform float4 _LightColor0; // this is not set in c# code ?
 
 struct VertexInput {
@@ -85,7 +87,7 @@ float4 frag(VertexOutput i) : SV_Target {
                                  : envLightSource_GradientEquator * _Unlit_Intensity;
     //
     float3 lightColor = _LightColor0.rgb > 0.05 ? _LightColor0.rgb : ambientSkyColor.rgb;
-    float lightColorIntensity = (0.299 * lightColor.r + 0.587 * lightColor.g + 0.114 * lightColor.b);
+    float lightColorIntensity = UTS_CalculateLightColorIntensity(lightColor);
     lightColor = lightColorIntensity < 1 ? lightColor : lightColor / lightColorIntensity;
     lightColor = lerp(half3(1.0, 1.0, 1.0), lightColor, _Is_LightColor_Outline);
     float2 Set_UV0 = i.uv0;

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
@@ -87,7 +87,7 @@ float4 frag(VertexOutput i) : SV_Target {
                                  : envLightSource_GradientEquator * _Unlit_Intensity;
     //
     float3 lightColor = _LightColor0.rgb > 0.05 ? _LightColor0.rgb : ambientSkyColor.rgb;
-    float lightColorIntensity = UTS_CalculateLightColorIntensity(lightColor);
+    float lightColorIntensity = Intensity(lightColor);
     lightColor = lightColorIntensity < 1 ? lightColor : lightColor / lightColorIntensity;
     lightColor = lerp(half3(1.0, 1.0, 1.0), lightColor, _Is_LightColor_Outline);
     float2 Set_UV0 = i.uv0;


### PR DESCRIPTION
Introduce a common shader function for color intensity calculation and refactor existing shaders to use it, reducing code duplication.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f6643b53-2983-4cdf-80ad-9a903395931c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f6643b53-2983-4cdf-80ad-9a903395931c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

